### PR TITLE
Fix `PackageSourceProvider.UpdatePackageSource` doesn't respect a value from `AllowInsecureConnection` field

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -567,7 +567,8 @@ namespace NuGet.Configuration
             if (string.Equals(newSource.Name, existingSource.Name, StringComparison.OrdinalIgnoreCase))
             {
                 if ((!string.Equals(newSource.Source, existingSource.Source, StringComparison.OrdinalIgnoreCase) ||
-                    newSource.ProtocolVersion != existingSource.ProtocolVersion) && newSource.IsPersistable)
+                    newSource.ProtocolVersion != existingSource.ProtocolVersion ||
+                    newSource.AllowInsecureConnections != existingSource.AllowInsecureConnections) && newSource.IsPersistable)
                 {
                     Settings.AddOrUpdate(ConfigurationConstants.PackageSources, newSource.AsSourceItem());
                     isDirty = true;

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1338,6 +1338,44 @@ namespace NuGet.Configuration.Test
             AssertPackageSource(values[2], "three", "threesource", true);
         }
 
+        [Fact]
+        public void UpdatePackageSource_ShouldUpdateAllowInsecureConnections()
+        {
+            using var directory = TestDirectory.Create();
+
+            // Arrange
+            var configContents = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                    <packageSources>
+                        <add key="default-http" value="http://api.nuget.org/v3/index.json" />
+                    </packageSources>
+                </configuration>
+                """;
+
+            File.WriteAllText(Path.Combine(directory.Path, "NuGet.Config"), configContents);
+
+            var settings = new Settings(directory);
+            var packageSourceProvider = new PackageSourceProvider(settings, TestConfigurationDefaults.NullInstance);
+            var source = packageSourceProvider.GetPackageSourceByName("default-http")!;
+
+            // Act
+            source.AllowInsecureConnections = true;
+            packageSourceProvider.UpdatePackageSource(source, false, false);
+
+            // Assert
+            settings = new Settings(directory);
+            var packageSourcesSection = settings.GetSection("packageSources");
+            packageSourcesSection.Should().NotBeNull();
+            packageSourcesSection!.Items.Count.Should().Be(1);
+            packageSourcesSection.Items.Should().AllBeOfType<SourceItem>();
+
+            var children = packageSourcesSection.Items.Cast<SourceItem>().ToList();
+            var parsedSource = children[0];
+            parsedSource.Key.Should().Be("default-http");
+            parsedSource.AllowInsecureConnections.Should().Be("True");
+        }
+
         // Test that a source added in a high priority config file is not
         // disabled by <disabledPackageSources> in a low priority file.
         [Theory]


### PR DESCRIPTION
Cherry-picking changes from upstream. They are required to implement [RIDER-93822](https://youtrack.jetbrains.com/issue/RIDER-93822): NET 8: Add settings 'force' for NuGet feeds

https://github.com/NuGet/NuGet.Client/pull/5767
